### PR TITLE
Favors Circle CI over Travis and Bamboo

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -1,7 +1,7 @@
 name,ring,quadrant,isNew,description  
 BetterCodeHub,adopt,tools,FALSE," .. "
-TravisCI,adopt,tools,FALSE," .. "
-CircleCI,trial,tools,TRUE," .. "
+TravisCI,hold,tools,FALSE,"At this moment we are migrating all builds to CircleCI because of better support of our current build flow"
+CircleCI,adopt,tools,TRUE,"At this moment we are migrating all builds to CircleCI because of better support of our current build flow"
 Dependabot,assess,tools,TRUE," .. "
 Atlassion Bamboo,hold,tools,FALSE,"We decided to favor Circle CI over Bamboo as its a SaaS service."
 Lightweight Architecture Decision Records,adopt,techniques,TRUE," .. "


### PR DESCRIPTION
**What this PR does?**
It puts TravisCI in the hold section and Circle CI in the adopt section. According to my info Circle CI is going to be the standard CI/CD build server for Intergamma. It supports our current Bamboo based workflow best and is provided as a service in the cloud helping to reduce maintenance cost.
